### PR TITLE
reference-ril: When we build with flag "BOARD_PROVIDES_LIBRIL" we

### DIFF
--- a/reference-ril/Android.mk
+++ b/reference-ril/Android.mk
@@ -31,7 +31,7 @@ ifeq ($(TARGET_DEVICE),dream)
   LOCAL_CFLAGS += -DPOLL_CALL_STATE -DUSE_QMI
 endif
 
-ifeq (foo,foo)
+ifneq ($(BOARD_PROVIDES_LIBRIL),true)
   #build shared library
   LOCAL_SHARED_LIBRARIES += \
       libcutils libutils


### PR DESCRIPTION
do not have a local shared library libril

Change-Id: I4f81b38500ae998dd52bcd1ae8b752b6ad8dc934